### PR TITLE
Make whitespace consistent

### DIFF
--- a/src/AuditoryFilters.jl
+++ b/src/AuditoryFilters.jl
@@ -2,21 +2,21 @@ module AuditoryFilters
 
 using DSP
 import Base: convert, filt
-export erb_space, make_erb_filterbank, erb_filterbank, compute_modulation_cfs, make_modulation_filter, modulation_filterbank, gammatonegram, 
-	   ERBFilterbank, ModulationFilterbank
+export erb_space, make_erb_filterbank, erb_filterbank, compute_modulation_cfs, make_modulation_filter, modulation_filterbank, gammatonegram,
+       ERBFilterbank, ModulationFilterbank
 
 abstract Filterbank
 
 nchannels(f::Filterbank) = length(f.filters)
 
 function filt(fb::Filterbank, x)
-	output = zeros(length(x), length(fb.filters))
-	@inbounds begin 
-		for k = 1:length(fb.filters)
-			output[:, k] = filt(fb.filters[k], x)
-		end
-	end
-	return output
+    output = zeros(length(x), length(fb.filters))
+    @inbounds begin
+        for k = 1:length(fb.filters)
+            output[:, k] = filt(fb.filters[k], x)
+        end
+    end
+    return output
 end
 
 include("ERBFilterbank.jl")

--- a/src/AuditoryFilters.jl
+++ b/src/AuditoryFilters.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module AuditoryFilters
 
 using DSP

--- a/src/ERBFilterbank.jl
+++ b/src/ERBFilterbank.jl
@@ -1,19 +1,19 @@
 immutable ERBFilterbank{C,G,T<:Real,U<:Real,V<:Real} <: Filterbank
-	filters::Vector{SecondOrderSections{C,G}}
-	ERB::Vector{T}
-  center_frequencies::Vector{U}
-  fs::V
+    filters::Vector{SecondOrderSections{C,G}}
+    ERB::Vector{T}
+    center_frequencies::Vector{U}
+    fs::V
 end
 
 function make_erb_filterbank(fs, num_channels, low_freq, EarQ = 9.26449, minBW = 24.7, order = 1)
     T = 1/fs
     if length(num_channels) == 1
-	cf = erb_space(low_freq, fs/2, num_channels)
+        cf = erb_space(low_freq, fs/2, num_channels)
     else
-	cf = num_channels
-	if size(cf,2) > size(cf,1)
-	    cf = cf'
-	end
+        cf = num_channels
+        if size(cf,2) > size(cf,1)
+        	cf = cf'
+        end
     end
     ERB = ((cf/EarQ).^order .+ minBW^order).^(1/order)
     B = 1.019*2*pi*ERB
@@ -39,17 +39,17 @@ function make_erb_filterbank(fs, num_channels, low_freq, EarQ = 9.26449, minBW =
       2^(3/2))*sin(2*cf*pi*T))) ./ (-2 ./ exp(2*B*T) -
       2*exp(4*im*cf*pi*T) + 2*(1 + exp(4*im*cf*pi*T))./exp(B*T)).^4)
 
-  C = typeof(B0)
-	filters = Array(SOSFilter{C,C}, num_channels)
-	for ch=1:num_channels
-		biquads = Array(BiquadFilter{C}, 4)
-		biquads[1] = BiquadFilter(B0, B11[ch], B2, A0, A1[ch], A2[ch])
-		biquads[2] = BiquadFilter(B0, B12[ch], B2, A0, A1[ch], A2[ch])
-		biquads[3] = BiquadFilter(B0, B13[ch], B2, A0, A1[ch], A2[ch])
-		biquads[4] = BiquadFilter(B0, B14[ch], B2, A0, A1[ch], A2[ch])
-		filters[ch] = SOSFilter(biquads, 1/gain[ch])
-	end
-	ERBFilterbank(filters, ERB, cf, fs)
+    C = typeof(B0)
+    filters = Array(SOSFilter{C,C}, num_channels)
+    for ch=1:num_channels
+        biquads = Array(BiquadFilter{C}, 4)
+        biquads[1] = BiquadFilter(B0, B11[ch], B2, A0, A1[ch], A2[ch])
+        biquads[2] = BiquadFilter(B0, B12[ch], B2, A0, A1[ch], A2[ch])
+        biquads[3] = BiquadFilter(B0, B13[ch], B2, A0, A1[ch], A2[ch])
+        biquads[4] = BiquadFilter(B0, B14[ch], B2, A0, A1[ch], A2[ch])
+        filters[ch] = SOSFilter(biquads, 1/gain[ch])
+    end
+    ERBFilterbank(filters, ERB, cf, fs)
 end
 
 function erb_space(low_freq, high_freq, num_channels, EarQ = 9.26449, minBW = 24.7, order = 1)

--- a/src/Gammatonegram.jl
+++ b/src/Gammatonegram.jl
@@ -1,76 +1,76 @@
-# Converts an FFT into a gammatonegram. Based on the gammatonegram/fft2gammatonemx MATLAB 
+# Converts an FFT into a gammatonegram. Based on the gammatonegram/fft2gammatonemx MATLAB
 # functions by Dan Ellis.
 # D. P. W. Ellis (2009). "Gammatone-like spectrograms", web resource.
 # http://www.ee.columbia.edu/~dpwe/resources/matlab/gammatonegram/
 
 type Gammatonegram{T, F<:Real} <: DSP.Periodograms.TFR{T}
-	amplitude::Matrix{T}
-	frequencies::Vector{F}
-	time::FloatRange{Float64}
+    amplitude::Matrix{T}
+    frequencies::Vector{F}
+    time::FloatRange{Float64}
 end
 
 function gammatonegram(x,sr::Integer,twin::Real,thop::Real,N::Integer,fmin,fmax,width)
-	nfft = int(2^(ceil(log(2*twin*sr)/log(2))))
+    nfft = int(2^(ceil(log(2*twin*sr)/log(2))))
     nhop = iround(thop*sr)
     nwin = iround(twin*sr)
     (W,F) = fft2gammatonemx(nfft, sr, N, width, fmin, fmax)
     # perform FFT and weighting in amplitude domain
-	S = stft(x, nwin, nwin-nhop; nfft=nfft, fs=sr, window=hanning)
-	Y = 1/nfft*W*abs(S)
-	Gammatonegram(Y, vec(F), ((0:size(Y,2)-1)*(nhop)+nwin/2)/sr)
+    S = stft(x, nwin, nwin-nhop; nfft=nfft, fs=sr, window=hanning)
+    Y = 1/nfft*W*abs(S)
+    Gammatonegram(Y, vec(F), ((0:size(Y,2)-1)*(nhop)+nwin/2)/sr)
 end
 
 function fft2gammatonemx(nfft::Integer, sr::Integer, N::Integer, width, fmin, fmax)
-	# Allocating matrix to store the filterbank weights
-	W = zeros(N, int(nfft/2+1));
-	# Gammatone filterbank constants
-	EarQ = 9.26449
-	minBW = 24.7
-	order = 1
+    # Allocating matrix to store the filterbank weights
+    W = zeros(N, int(nfft/2+1));
+    # Gammatone filterbank constants
+    EarQ = 9.26449
+    minBW = 24.7
+    order = 1
 
-	cfreqs = -(EarQ*minBW) + exp((1:N)'*(-log(fmax + EarQ*minBW) + log(fmin + EarQ*minBW))/N) * (fmax + EarQ*minBW);
-	cfreqs = fliplr(cfreqs)
-	GTord = 4
-	ucirc = exp(im*2*pi*[0:(nfft/2)]/nfft)
-	for k=1:N
-	    cf = cfreqs[k];
-	    ERB = width*((cf/EarQ).^order + minBW^order).^(1/order);
-	    B = 1.019*2*pi*ERB;
-	    r = exp(-B/sr);
-	    theta = 2*pi*cf/sr;
-	    pole = r*exp(im*theta);
-	    T = 1/sr;
-	    
-		A11 = -(2*T*cos(2*cf*pi*T)./exp(B*T) + 2*sqrt(3+2^1.5)*T*sin(2*
-	                                                      cf*pi*T)./exp(B*T))/2; 
-	    A12 = -(2*T*cos(2*cf*pi*T)./exp(B*T) - 2*sqrt(3+2^1.5)*T*sin(2*
-	                                                      cf*pi*T)./exp(B*T))/2;
-	    A13 = -(2*T*cos(2*cf*pi*T)./exp(B*T) + 2*sqrt(3-2^1.5)*T*sin(2*
-	                                                      cf*pi*T)./exp(B*T))/2; 
-	    A14 = -(2*T*cos(2*cf*pi*T)./exp(B*T) - 2*sqrt(3-2^1.5)*T*sin(2*
-	                                                      cf*pi*T)./exp(B*T))/2; 
-	    zros = -[A11 A12 A13 A14]/T;
-    
-	    gain =  abs((-2*exp(4*im*cf*pi*T)*T + 
-	                2*exp(-(B*T) + 2*im*cf*pi*T).*T.* 
-	                (cos(2*cf*pi*T) - sqrt(3 - 2^(3/2))* 
-	                 sin(2*cf*pi*T))) .* 
-	               (-2*exp(4*im*cf*pi*T)*T + 
-	                2*exp(-(B*T) + 2*im*cf*pi*T).*T.* 
-	                (cos(2*cf*pi*T) + sqrt(3 - 2^(3/2)) * 
-	                 sin(2*cf*pi*T))).* 
-	               (-2*exp(4*im*cf*pi*T)*T + 
-	                2*exp(-(B*T) + 2*im*cf*pi*T).*T.* 
-	                (cos(2*cf*pi*T) - 
-	                 sqrt(3 + 2^(3/2))*sin(2*cf*pi*T))) .* 
-	               (-2*exp(4*im*cf*pi*T)*T + 2*exp(-(B*T) + 2*im*cf*pi*T).*T.* 
-	                (cos(2*cf*pi*T) + sqrt(3 + 2^(3/2))*sin(2*cf*pi*T))) ./ 
-	               (-2 ./ exp(2*B*T) - 2*exp(4*im*cf*pi*T) +  
-	                2*(1 + exp(4*im*cf*pi*T))./exp(B*T)).^4);
-	    W[k,:] = ((T^4)/gain) *
-	        abs(ucirc-zros[1]).*abs(ucirc-zros[2]) .*
-	        abs(ucirc-zros[3]).*abs(ucirc-zros[4]) .*
-	        (abs((pole-ucirc).*(pole'-ucirc)).^-GTord);
-	end
-	W, cfreqs	
+    cfreqs = -(EarQ*minBW) + exp((1:N)'*(-log(fmax + EarQ*minBW) + log(fmin + EarQ*minBW))/N) * (fmax + EarQ*minBW);
+    cfreqs = fliplr(cfreqs)
+    GTord = 4
+    ucirc = exp(im*2*pi*[0:(nfft/2)]/nfft)
+    for k=1:N
+        cf = cfreqs[k];
+        ERB = width*((cf/EarQ).^order + minBW^order).^(1/order);
+        B = 1.019*2*pi*ERB;
+        r = exp(-B/sr);
+        theta = 2*pi*cf/sr;
+        pole = r*exp(im*theta);
+        T = 1/sr;
+
+        A11 = -(2*T*cos(2*cf*pi*T)./exp(B*T) + 2*sqrt(3+2^1.5)*T*sin(2*
+                                                          cf*pi*T)./exp(B*T))/2;
+        A12 = -(2*T*cos(2*cf*pi*T)./exp(B*T) - 2*sqrt(3+2^1.5)*T*sin(2*
+                                                          cf*pi*T)./exp(B*T))/2;
+        A13 = -(2*T*cos(2*cf*pi*T)./exp(B*T) + 2*sqrt(3-2^1.5)*T*sin(2*
+                                                          cf*pi*T)./exp(B*T))/2;
+        A14 = -(2*T*cos(2*cf*pi*T)./exp(B*T) - 2*sqrt(3-2^1.5)*T*sin(2*
+                                                          cf*pi*T)./exp(B*T))/2;
+        zros = -[A11 A12 A13 A14]/T;
+
+        gain =  abs((-2*exp(4*im*cf*pi*T)*T +
+                    2*exp(-(B*T) + 2*im*cf*pi*T).*T.*
+                    (cos(2*cf*pi*T) - sqrt(3 - 2^(3/2))*
+                     sin(2*cf*pi*T))) .*
+                   (-2*exp(4*im*cf*pi*T)*T +
+                    2*exp(-(B*T) + 2*im*cf*pi*T).*T.*
+                    (cos(2*cf*pi*T) + sqrt(3 - 2^(3/2)) *
+                     sin(2*cf*pi*T))).*
+                   (-2*exp(4*im*cf*pi*T)*T +
+                    2*exp(-(B*T) + 2*im*cf*pi*T).*T.*
+                    (cos(2*cf*pi*T) -
+                     sqrt(3 + 2^(3/2))*sin(2*cf*pi*T))) .*
+                   (-2*exp(4*im*cf*pi*T)*T + 2*exp(-(B*T) + 2*im*cf*pi*T).*T.*
+                    (cos(2*cf*pi*T) + sqrt(3 + 2^(3/2))*sin(2*cf*pi*T))) ./
+                   (-2 ./ exp(2*B*T) - 2*exp(4*im*cf*pi*T) +
+                    2*(1 + exp(4*im*cf*pi*T))./exp(B*T)).^4);
+        W[k,:] = ((T^4)/gain) *
+            abs(ucirc-zros[1]).*abs(ucirc-zros[2]) .*
+            abs(ucirc-zros[3]).*abs(ucirc-zros[4]) .*
+            (abs((pole-ucirc).*(pole'-ucirc)).^-GTord);
+    end
+    W, cfreqs
 end

--- a/src/ModulationFilterbank.jl
+++ b/src/ModulationFilterbank.jl
@@ -1,7 +1,7 @@
 immutable ModulationFilterbank{F<:FilterCoefficients,T<:Real,U<:Real} <: Filterbank
-	filters::Vector{F}
-	center_frequencies::Vector{T}
-	fs::U
+    filters::Vector{F}
+    center_frequencies::Vector{T}
+    fs::U
 end
 
 function make_modulation_filter(w0, Q)


### PR DESCRIPTION
Converts the whitespace to a uniform spaces instead of tabs and spaces mixed, also enables precompilation for (slightly) faster `using` times.